### PR TITLE
Migrate to Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ Firstly make sure you've got a functioning Pi camera module (test it with
 `raspistill` to be certain). Then make sure you've got the following packages
 installed:
 
-    $ sudo apt-get install libav-tools git python-setuptools python-pip python-picamera
-    $ sudo pip install ws4py
+    $ sudo apt-get install libav-tools git python3-picamera python3-ws4py
 
 Next, clone this repository:
 
@@ -28,7 +27,7 @@ Run the Python server script which should print out a load of stuff
 to the console as it starts up:
 
     $ cd pistreaming
-    $ python server.py
+    $ python3 server.py
     Initializing websockets server on port 8084
     Initializing HTTP server on port 8082
     Initializing camera

--- a/server.py
+++ b/server.py
@@ -1,16 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import (
-    unicode_literals,
-    absolute_import,
-    print_function,
-    division,
-    )
-native_str = str
-str = type('')
-
 import sys
-PY2 = sys.version_info.major == 2
 import io
 import os
 import shutil
@@ -19,7 +9,7 @@ from string import Template
 from struct import Struct
 from threading import Thread
 from time import sleep, time
-from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
+from http.server import HTTPServer, BaseHTTPRequestHandler
 from wsgiref.simple_server import make_server
 
 import picamera
@@ -37,7 +27,7 @@ WS_PORT = 8084
 COLOR = u'#444'
 BGCOLOR = u'#333'
 JSMPEG_MAGIC = b'jsmp'
-JSMPEG_HEADER = Struct(native_str('>4sHH'))
+JSMPEG_HEADER = Struct('>4sHH')
 ###########################################
 
 
@@ -75,12 +65,8 @@ class StreamingHttpHandler(BaseHTTPRequestHandler):
 
 class StreamingHttpServer(HTTPServer):
     def __init__(self):
-        # Eurgh ... old-style classes ...
-        if PY2:
-            HTTPServer.__init__(self, ('', HTTP_PORT), StreamingHttpHandler)
-        else:
-            super(StreamingHttpServer, self).__init__(
-                    ('', HTTP_PORT), StreamingHttpHandler)
+        super(StreamingHttpServer, self).__init__(
+                ('', HTTP_PORT), StreamingHttpHandler)
         with io.open('index.html', 'r') as f:
             self.index_template = f.read()
         with io.open('jsmpg.js', 'r') as f:


### PR DESCRIPTION
Now that ws4py is packaged on Raspbian, and Python 3.4 is available
there's precious little reason to stick with Python 2 for a demo. This
cleans up the instructions and moves the script over to Python 3.